### PR TITLE
Use Zod schemas for workflow DTO validation

### DIFF
--- a/src/modules/workflow/dto/create-workflow.dto.ts
+++ b/src/modules/workflow/dto/create-workflow.dto.ts
@@ -1,19 +1,14 @@
-import { IsString, IsNotEmpty, IsOptional, IsArray } from 'class-validator';
+import { z } from 'zod';
+import { createZodDto } from 'nestjs-zod';
 
-export class CreateWorkflowDto {
-  @IsString()
-  @IsNotEmpty()
-  name: string;
+// Schema for workflow creation. Nodes and edges are represented as
+// arrays of arbitrary objects because their structure is handled on
+// the client side.
+export const WorkflowSchema = z.object({
+  name: z.string().min(1),
+  description: z.string().optional(),
+  nodes: z.array(z.any()).nonempty(),
+  edges: z.array(z.any()).nonempty(),
+});
 
-  @IsString()
-  @IsOptional()
-  description?: string;
-
-  @IsArray()
-  @IsNotEmpty()
-  nodes: any[];
-
-  @IsArray()
-  @IsNotEmpty()
-  edges: any[];
-}
+export class CreateWorkflowDto extends createZodDto(WorkflowSchema) {}

--- a/src/modules/workflow/dto/update-workflow.dto.ts
+++ b/src/modules/workflow/dto/update-workflow.dto.ts
@@ -1,4 +1,8 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateWorkflowDto } from './create-workflow.dto';
+import { createZodDto } from 'nestjs-zod';
+import { WorkflowSchema } from './create-workflow.dto';
 
-export class UpdateWorkflowDto extends PartialType(CreateWorkflowDto) {}
+// Update DTO allows partial updates of the workflow fields.
+export class UpdateWorkflowDto extends createZodDto(
+  WorkflowSchema.partial()
+) {}
+


### PR DESCRIPTION
## Summary
- replace class-validator with Zod-based schema for workflow creation
- allow partial workflow updates with Zod schema

## Testing
- `npm run lint` (fails: Unsafe argument of type `any` and other lint errors)
- `npm test` (fails: missing module imports)


------
https://chatgpt.com/codex/tasks/task_e_68b56f6dc9988323b7d203c10bc03399