### PR TITLE
fix: allow new workflow node types

### DIFF
--- a/src/modules/workflow/dto/node.dto.ts
+++ b/src/modules/workflow/dto/node.dto.ts
@@ -3,7 +3,19 @@ import { createZodDto } from 'nestjs-zod';
 
 export const NodeSchema = z.object({
   id: z.string(),
-  type: z.enum(['procurement-request', 'condition-if-else', 'condition-case', 'parallel-fork', 'parallel-join', 'form', 'email']),
+  type: z.enum([
+    'procurement-request',
+    'condition-if-else',
+    'condition-case',
+    'parallel-fork',
+    'parallel-join',
+    'form',
+    'email',
+    'purchaseRequest',
+    'condition',
+    'purchaseRequestApprove',
+    'purchaseRequestReject',
+  ]),
   position: z.object({
     x: z.number(),
     y: z.number(),


### PR DESCRIPTION
## Summary
- expand workflow node validation with purchase request and approval types

## Testing
- `npm test` *(fails: Cannot find module '../services/phase1.service'...)*
- `npm run lint` *(fails: 844 problems, 761 errors, 83 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68b571353e5483239836ed23d233f3b8